### PR TITLE
Ensure own ldexp implementation is used

### DIFF
--- a/src/ltitop/algorithms/__init__.py
+++ b/src/ltitop/algorithms/__init__.py
@@ -71,12 +71,13 @@ class Algorithm:
                 local_variables = [v for v in variables if expression.has(v)]
                 local_constants = [c for c in constants if expression.has(c)]
                 import ltitop.algorithms.expressions.arithmetic as arithmetic
+                import ltitop.arithmetic.symbolic as symbolic
 
                 func = functools.partial(
                     sympy.lambdify(
                         local_constants + arguments + local_variables,
                         expression,
-                        modules=[arithmetic, "numpy"],
+                        modules=[symbolic, arithmetic, "numpy"],
                     ),
                     *[constants[c] for c in local_constants],
                 )

--- a/src/ltitop/arithmetic/symbolic.py
+++ b/src/ltitop/arithmetic/symbolic.py
@@ -267,7 +267,7 @@ class BaseNumber(AtomicExpr):
         return self._new(self._args[0] >> n)
 
 
-class ldexp(Function):
+class LoadExponent(Function):
     @classmethod
     def eval(cls, x, k):
         if isinstance(x, (BaseNumber, Number)) and isinstance(k, (BaseNumber, Number)):

--- a/src/ltitop/topology/realizations/direct_forms.py
+++ b/src/ltitop/topology/realizations/direct_forms.py
@@ -30,7 +30,7 @@ from ltitop.algorithms import Algorithm
 from ltitop.algorithms.statements import Assignment
 from ltitop.arithmetic.floating_point import mpfloat
 from ltitop.arithmetic.interval import interval
-from ltitop.arithmetic.symbolic import ldexp
+from ltitop.arithmetic.symbolic import LoadExponent
 from ltitop.common.arrays import asvector_if_possible, within
 from ltitop.common.dataclasses import immutable_dataclass
 from ltitop.common.helpers import identity
@@ -240,7 +240,7 @@ class DirectFormI(DirectForm):
             parameters = b, a, k
 
             def f(_):
-                return ldexp(_, k)
+                return LoadExponent(_, k)
 
         else:
             parameters = b, a
@@ -331,7 +331,7 @@ class DirectFormII(DirectForm):
             parameters = b, a, k
 
             def f(_):
-                return ldexp(_, k)
+                return LoadExponent(_, k)
 
         else:
             parameters = b, a
@@ -423,7 +423,7 @@ class TransposedDirectFormII(DirectForm):
             parameters = b, a, k
 
             def f(_):
-                return ldexp(_, k)
+                return LoadExponent(_, k)
 
         else:
             parameters = b, a


### PR DESCRIPTION
### Proposed changes

On Python 3.8, `simpy.lambdify` was no longer using `ltitop`'s symbolic `ldexp` implementation. Change upstream?

#### Type of change

- [x] 🐛 Bugfix (change which fixes an issue)
- [ ] 🚀 Feature (change which adds functionality)
- [ ] 📚 Documentation (change which fixes or extends documentation)

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules